### PR TITLE
feat: when failing to parse address, retry with text after the first line

### DIFF
--- a/utils/location.py
+++ b/utils/location.py
@@ -143,9 +143,9 @@ def get_address(full_location):
             if "," in full_location:
                 location = geocode_location_string(full_location.split(",", 1)[1])
         if location is None:
-            lines = full_location.splitlines()
+            lines = full_location.splitlines(keepends=True)
             if len(lines) > 1:
-                location = geocode_location_string("\n".join(lines[1:]))
+                location = geocode_location_string("".join(lines[1:]))
         if location is None:
             raise FreskAddressNotFound(full_location)
 

--- a/utils/location.py
+++ b/utils/location.py
@@ -1,5 +1,6 @@
 import logging
 
+from functools import lru_cache
 from utils.errors import *
 
 from geopy.geocoders import Nominatim
@@ -113,19 +114,14 @@ departments = {
 cache = {}
 
 
+@lru_cache(maxsize=None)
 def geocode_location_string(location_string):
     """
     Requests Nomatim to geocode an input string. All results are cached and
-    reused.
+    reused thanks to the @lru_cache decorator.
     """
-    location = None
-    if location_string in cache:
-        location = cache[location_string]
-    else:
-        logging.info(f"Calling geocoder with {location_string}...")
-        location = geolocator.geocode(location_string, addressdetails=True)
-        cache[location_string] = location
-    return location
+    logging.info(f"Calling geocoder: {location_string}")
+    return geolocator.geocode(location_string, addressdetails=True)
 
 
 def get_address(full_location):


### PR DESCRIPTION
This builds upon the logic added in #49 by handling multiline text and retrying the parse without the first line. `str.splitlines` is called to maximize the coverage.

This recovers all addresses for Mon Tour (https://www.helloasso.com/associations/mush) instead of just the last few.